### PR TITLE
Prepare 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 - 2026-01-09
+
+### Breaking Changes
+
+- Dropped support for Nextcloud 32, 31, 30, and 29
+
+### Changed
+
+- Use new Nextcloud files library @lukasdotcom [#48](https://github.com/nextcloud/integration_overleaf/pull/48)
+
 ## 1.1.0 - 2025-11-10
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Overleaf</name>
 	<summary>Integration of Overleaf</summary>
 	<description>App to edit LaTeX files using Overleaf.</description>
-	<version>1.1.0</version>
+	<version>2.0.0</version>
 	<licence>agpl</licence>
 	<author mail="lukas@lschaefer.xyz" homepage="https://github.com/lukasdotcom">Lukas Schaefer</author>
 	<namespace>Overleaf</namespace>


### PR DESCRIPTION
## 2.0.0 - 2026-01-09

### Breaking Changes

- Dropped support for Nextcloud 32, 31, 30, and 29

### Changed

- Use new Nextcloud files library @lukasdotcom [#48](https://github.com/nextcloud/integration_overleaf/pull/48)