### PR TITLE
Chore: Prepare 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.1 - 2026-02-23
+
+### Added
+
+- Added support for Nextcloud 34
+
+### Changed
+
+- No more FileAction class @julien-nc [#48](https://github.com/nextcloud/integration_overleaf/pull/61)
+
 ## 2.0.0 - 2026-01-09
 
 ### Breaking Changes

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Overleaf</name>
 	<summary>Integration of Overleaf</summary>
 	<description>App to edit LaTeX files using Overleaf.</description>
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<licence>agpl</licence>
 	<author mail="lukas@lschaefer.xyz" homepage="https://github.com/lukasdotcom">Lukas Schaefer</author>
 	<namespace>Overleaf</namespace>


### PR DESCRIPTION
## 2.0.1 - 2026-02-23

### Added

- Added support for Nextcloud 34

### Changed

- No more FileAction class @julien-nc [#48](https://github.com/nextcloud/integration_overleaf/pull/61)