### PR TITLE
Prepare 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.2 - 2026-07-22
+
+### Added
+
+- Added support for Nextcloud 35 @lukasdotcom [#69](https://github.com/nextcloud/integration_overleaf/pull/69)
+
+### Changed
+
+- Update dependencies and workflows @lukasdotcom [#69](https://github.com/nextcloud/integration_overleaf/pull/69)
+
 ## 2.0.1 - 2026-02-23
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Overleaf</name>
 	<summary>Integration of Overleaf</summary>
 	<description>App to edit LaTeX files using Overleaf.</description>
-	<version>2.0.1</version>
+	<version>2.0.2</version>
 	<licence>agpl</licence>
 	<author mail="lukas@lschaefer.xyz" homepage="https://github.com/lukasdotcom">Lukas Schaefer</author>
 	<namespace>Overleaf</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "integration_overleaf",
-  "version": "1.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "integration_overleaf",
-      "version": "1.0.0",
+      "version": "2.0.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/axios": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration_overleaf",
-  "version": "1.0.0",
+  "version": "2.0.2",
   "license": "AGPL-3.0-or-later",
   "engines": {
     "node": "^24.0.0",


### PR DESCRIPTION
## 2.0.2 - 2026-07-22

### Added

- Added support for Nextcloud 35 @lukasdotcom [#69](https://github.com/nextcloud/integration_overleaf/pull/69)

### Changed

- Update dependencies and workflows @lukasdotcom [#69](https://github.com/nextcloud/integration_overleaf/pull/69)